### PR TITLE
fix: Declare CodeMirror as external variable

### DIFF
--- a/src/lib/codemirror.component.ts
+++ b/src/lib/codemirror.component.ts
@@ -30,9 +30,7 @@ function normalizeLineEndings(str: string) {
 }
 
 declare var require: any;
-/* tslint:disable */
-var CodeMirror: any;
-/* tslint:enable */
+declare var CodeMirror: any;
 
 @Component({
   selector: 'ngx-codemirror',
@@ -106,7 +104,7 @@ export class CodemirrorComponent
       return this._codeMirror;
     }
 
-    this._codeMirror = CodeMirror ? CodeMirror : require('codemirror');
+    this._codeMirror = typeof CodeMirror !== 'undefined' ? CodeMirror : require('codemirror');
     return this._codeMirror;
   }
 


### PR DESCRIPTION
The current var CodeMirror statement is creating a new variable in this file that is never being set. Based on comments, it appears that the original intention is to access the global variable we get from pulling in the CodeMirror library. This updates it to use the syntax for declaring an external variable.